### PR TITLE
feat: add the analyze page parameter

### DIFF
--- a/layouts/partials/hugopress/modules/plausible-analytics/hooks/head-end.html
+++ b/layouts/partials/hugopress/modules/plausible-analytics/hooks/head-end.html
@@ -1,1 +1,3 @@
-{{ partial "plausible-analytics/assets/js" .Page }}
+{{- if default true .Page.Params.analyze }}
+  {{ partial "plausible-analytics/assets/js" .Page }}
+{{- end }}


### PR DESCRIPTION
To exclude specified pages from being tracked by setting analyze as false.

Fixes #3 